### PR TITLE
Add comprehensive Google OAuth setup documentation

### DIFF
--- a/AUTHENTICATION_SETUP.md
+++ b/AUTHENTICATION_SETUP.md
@@ -3,88 +3,86 @@
 ## Overview
 This guide explains how to properly configure Google OAuth for the Spark Scout application to avoid the "redirect_uri_mismatch" error you're encountering.
 
-## Steps to Fix the OAuth Error
+## Current Configuration Status
+Based on your Google Cloud Console configuration, you already have the correct redirect URIs set up:
+- Production: `https://spark-scout-eosin.vercel.app/api/auth/callback/google`
+- Production: `https://chat.opulentia.ai/api/auth/callback/google`
+- Preview: `https://spark-scout-buvonz69m-agent-space-7f0053b9.vercel.app/api/auth/callback/google`
+- Local development: `https://localhost:3000/api/auth/callback/google`
 
-### 1. Access Google Cloud Console
-Go to https://console.cloud.google.com/ and select your project (or create one if you haven't already).
+## Environment Variables Setup
 
-### 2. Configure OAuth Consent Screen
-Navigate to "APIs & Services" > "OAuth consent screen":
-1. Set the User Type (Internal or External)
-2. Fill in the required App information:
-   - App name
-   - User support email
-   - Developer contact information
-3. Add authorized domains that match your deployment URLs
-4. Save the configuration
+### Required Environment Variables
+For your Google OAuth integration to work correctly, you need to set these environment variables in Vercel:
 
-### 3. Create OAuth 2.0 Client IDs
-Navigate to "APIs & Services" > "Credentials" > "+ CREATE CREDENTIALS" > "OAuth client ID":
-1. Select Application type: "Web application"
-2. Add authorized redirect URIs based on your deployment environment:
+1. `AUTH_GOOGLE_ID` - Your Google OAuth client ID from the Google Cloud Console
+2. `AUTH_GOOGLE_SECRET` - Your Google OAuth client secret from the Google Cloud Console
+3. `AUTH_SECRET` - A random string used to hash tokens and sign cookies
 
-#### For Local Development
-```
-http://localhost:3000/api/auth/callback/google
-```
+### How to Set Environment Variables in Vercel
 
-#### For Vercel Preview Deployments (add each preview URL)
-Example format:
-```
-https://your-app-git-branch-name.vercel.app/api/auth/callback/google
-```
-
-#### For Production Deployment
-```
-https://yourdomain.com/api/auth/callback/google
-```
-
-### 4. Environment Variables
-Add the following environment variables to your deployment platform:
-
-#### For Vercel
-In your Vercel project settings, go to "Environment Variables" and add:
-- `AUTH_GOOGLE_ID` - Your Google OAuth client ID
-- `AUTH_GOOGLE_SECRET` - Your Google OAuth client secret
-- `AUTH_SECRET` - A random secret (generate at https://generate-secret.vercel.app/32)
-
-#### For Local Development
-Create a `.env.local` file in your project root with:
-```env
-AUTH_GOOGLE_ID=your_google_client_id
-AUTH_GOOGLE_SECRET=your_google_client_secret
-AUTH_SECRET=your_random_secret
-```
-
-### 5. Special Considerations for Preview Deployments
-Since Google OAuth does not support wildcards, preview deployments will require manual addition of redirect URIs. For a more scalable solution, consider:
-
-1. Using the Credentials Provider for preview deployments instead of OAuth providers
-2. Setting up a fixed domain for authentication that works across all deployments
-3. Using `AUTH_REDIRECT_PROXY_URL` to force a specific callback URL:
+1. Go to your Vercel Dashboard
+2. Select your Spark-Scout project
+3. Go to Settings > Environment Variables
+4. Add the following variables:
+   
    ```
-   AUTH_REDIRECT_PROXY_URL=https://yourdomain.com
+   AUTH_GOOGLE_ID=YOUR_GOOGLE_CLIENT_ID
+   AUTH_GOOGLE_SECRET=YOUR_GOOGLE_CLIENT_SECRET
+   AUTH_SECRET=RANDOM_SECRET_STRING
    ```
+
+### Generating a Secure AUTH_SECRET
+
+You can generate a secure AUTH_SECRET using one of these methods:
+
+1. Visit https://generate-secret.vercel.app/32
+2. Or run this command in your terminal:
+   ```bash
+   openssl rand -base64 32
+   ```
+
+## Vercel Deployments with NextAuth.js
+
+### Default Behavior
+By default, Vercel automatically provides the correct URL to NextAuth.js, so you don't typically need to set `NEXTAUTH_URL`.
+
+### For Preview Deployments
+Since you have multiple preview environments, you should consider setting:
+```
+AUTH_REDIRECT_PROXY_URL=https://spark-scout-eosin.vercel.app
+```
+
+This environment variable ensures that all OAuth callbacks go through your stable domain regardless of which preview URL is being used.
+
+### Additional Vercel Configuration
+You may also want to set:
+```
+AUTH_TRUST_HOST=true
+```
+
+This tells NextAuth.js to trust the host header provided by Vercel.
 
 ## Troubleshooting Tips
 
 1. Ensure that all redirect URIs exactly match what's configured in Google Cloud Console, including protocol, host, path, and trailing slashes.
 
-2. If you continue to experience issues, manually test the OAuth flow by constructing the authorization URL:
-   ```
-   https://accounts.google.com/o/oauth2/auth?
-     client_id=YOUR_CLIENT_ID&
-     redirect_uri=YOUR_REDIRECT_URI&
-     scope=openid email profile&
-     response_type=code&
-     access_type=offline
-   ```
+2. Remember that changes in Google Cloud Console may take up to 5 minutes to propagate.
 
-3. Remember that changes in Google Cloud Console may take a few minutes to propagate.
+3. Check that your OAuth client ID has not been restricted to specific IPs or domains.
 
-4. Check that your OAuth client ID has not been restricted to specific IPs or domains.
+4. For domain-based setups, verify that your domain is verified in Google Search Console.
 
-5. For domain-based setups, verify that your domain is verified in Google Search Console.
+5. If issues persist, try clearing your browser cookies for the domain and try signing in again.
 
 For more information, see the NextAuth.js documentation on Google provider configuration:
 https://next-auth.js.org/providers/google
+
+## Specific to Your Setup
+
+Based on your domain configuration, you should add environment variables in Vercel for all three environments:
+1. Production (`spark-scout-eosin.vercel.app`)
+2. Production (`chat.opulentia.ai`)
+3. Preview deployments (Note: Google OAuth doesn't support wildcards, so you may need to update this as new preview URLs are created)
+
+The most important step now is to ensure your `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET` environment variables are set correctly in Vercel, matching the credentials from your Google Cloud Console OAuth 2.0 client.

--- a/AUTHENTICATION_SETUP.md
+++ b/AUTHENTICATION_SETUP.md
@@ -1,0 +1,90 @@
+# Google OAuth Setup Guide
+
+## Overview
+This guide explains how to properly configure Google OAuth for the Spark Scout application to avoid the "redirect_uri_mismatch" error you're encountering.
+
+## Steps to Fix the OAuth Error
+
+### 1. Access Google Cloud Console
+Go to https://console.cloud.google.com/ and select your project (or create one if you haven't already).
+
+### 2. Configure OAuth Consent Screen
+Navigate to "APIs & Services" > "OAuth consent screen":
+1. Set the User Type (Internal or External)
+2. Fill in the required App information:
+   - App name
+   - User support email
+   - Developer contact information
+3. Add authorized domains that match your deployment URLs
+4. Save the configuration
+
+### 3. Create OAuth 2.0 Client IDs
+Navigate to "APIs & Services" > "Credentials" > "+ CREATE CREDENTIALS" > "OAuth client ID":
+1. Select Application type: "Web application"
+2. Add authorized redirect URIs based on your deployment environment:
+
+#### For Local Development
+```
+http://localhost:3000/api/auth/callback/google
+```
+
+#### For Vercel Preview Deployments (add each preview URL)
+Example format:
+```
+https://your-app-git-branch-name.vercel.app/api/auth/callback/google
+```
+
+#### For Production Deployment
+```
+https://yourdomain.com/api/auth/callback/google
+```
+
+### 4. Environment Variables
+Add the following environment variables to your deployment platform:
+
+#### For Vercel
+In your Vercel project settings, go to "Environment Variables" and add:
+- `AUTH_GOOGLE_ID` - Your Google OAuth client ID
+- `AUTH_GOOGLE_SECRET` - Your Google OAuth client secret
+- `AUTH_SECRET` - A random secret (generate at https://generate-secret.vercel.app/32)
+
+#### For Local Development
+Create a `.env.local` file in your project root with:
+```env
+AUTH_GOOGLE_ID=your_google_client_id
+AUTH_GOOGLE_SECRET=your_google_client_secret
+AUTH_SECRET=your_random_secret
+```
+
+### 5. Special Considerations for Preview Deployments
+Since Google OAuth does not support wildcards, preview deployments will require manual addition of redirect URIs. For a more scalable solution, consider:
+
+1. Using the Credentials Provider for preview deployments instead of OAuth providers
+2. Setting up a fixed domain for authentication that works across all deployments
+3. Using `AUTH_REDIRECT_PROXY_URL` to force a specific callback URL:
+   ```
+   AUTH_REDIRECT_PROXY_URL=https://yourdomain.com
+   ```
+
+## Troubleshooting Tips
+
+1. Ensure that all redirect URIs exactly match what's configured in Google Cloud Console, including protocol, host, path, and trailing slashes.
+
+2. If you continue to experience issues, manually test the OAuth flow by constructing the authorization URL:
+   ```
+   https://accounts.google.com/o/oauth2/auth?
+     client_id=YOUR_CLIENT_ID&
+     redirect_uri=YOUR_REDIRECT_URI&
+     scope=openid email profile&
+     response_type=code&
+     access_type=offline
+   ```
+
+3. Remember that changes in Google Cloud Console may take a few minutes to propagate.
+
+4. Check that your OAuth client ID has not been restricted to specific IPs or domains.
+
+5. For domain-based setups, verify that your domain is verified in Google Search Console.
+
+For more information, see the NextAuth.js documentation on Google provider configuration:
+https://next-auth.js.org/providers/google

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -36,7 +36,11 @@ Option B — Temporal Cloud (production)
 
 3) Vercel (Frontend)
 - Set env vars in Project Settings → Environment Variables:
-  - AUTH_SECRET
+  - AUTH_GOOGLE_ID (required for Google OAuth)
+  - AUTH_GOOGLE_SECRET (required for Google OAuth)
+  - AUTH_SECRET (required for NextAuth.js)
+  - AUTH_REDIRECT_PROXY_URL (optional but recommended for preview deployments)
+  - AUTH_TRUST_HOST (optional but recommended for Vercel deployments)
   - TEMPORAL_ADDRESS
   - TEMPORAL_NAMESPACE
   - TEMPORAL_TLS (true/false)
@@ -48,6 +52,7 @@ Option B — Temporal Cloud (production)
 - New chat starts a Temporal workflow (first user message)
 - Model selector change signals updateModel when a workflow exists
 - Enhanced selector shows Pending approvals and Approve/Deny
+- Google OAuth sign-in works without redirect_uri_mismatch errors
 
 CLI Quick Reference
 - Railway
@@ -58,7 +63,12 @@ CLI Quick Reference
   - railway variables --set "TEMPORAL_ADDRESS=<host:port>" --set "TEMPORAL_NAMESPACE=default" --set "TEMPORAL_TLS=false"
   - railway up --service temporal-worker --detach
 - Vercel
+  - vercel login
+  - vercel env add AUTH_GOOGLE_ID production
+  - vercel env add AUTH_GOOGLE_SECRET production
   - vercel env add AUTH_SECRET production
+  - vercel env add AUTH_REDIRECT_PROXY_URL production
+  - vercel env add AUTH_TRUST_HOST production
   - vercel env add TEMPORAL_ADDRESS production
   - vercel env add TEMPORAL_NAMESPACE production
   - vercel env add TEMPORAL_TLS production
@@ -67,3 +77,4 @@ CLI Quick Reference
 Security Notes
 - Do not commit secrets to the repository.
 - Rotate any credentials that were shared in plaintext or committed accidentally.
+- Your Google OAuth client credentials should never be exposed publicly.

--- a/OAUTH_ENV_VARIABLES.md
+++ b/OAUTH_ENV_VARIABLES.md
@@ -1,0 +1,58 @@
+# OAuth Environment Variables Configuration
+
+Based on your Google Cloud Console OAuth 2.0 client configuration, you need to set the following environment variables in your Vercel project:
+
+## Required Environment Variables
+
+1. `AUTH_GOOGLE_ID` - Your Google OAuth client ID
+2. `AUTH_GOOGLE_SECRET` - Your Google OAuth client secret
+3. `AUTH_SECRET` - A random secret used to hash tokens and sign cookies
+
+## How to Set Environment Variables in Vercel
+
+1. Go to your Vercel Dashboard
+2. Select your project
+3. Go to Settings > Environment Variables
+4. Add the following variables:
+   
+   ```
+   AUTH_GOOGLE_ID=YOUR_GOOGLE_CLIENT_ID
+   AUTH_GOOGLE_SECRET=YOUR_GOOGLE_CLIENT_SECRET
+   AUTH_SECRET=GENERATED_RANDOM_SECRET
+   ```
+
+## Generating a Secure AUTH_SECRET
+
+You can generate a secure AUTH_SECRET using one of these methods:
+
+1. Visit https://generate-secret.vercel.app/32
+2. Or run this command in your terminal:
+   ```bash
+   openssl rand -base64 32
+   ```
+
+## Vercel Preview Deployments
+
+For preview deployments like `https://spark-scout-*.vercel.app`, you have two options:
+
+1. **Add each preview URL manually** to your Google Cloud Console:
+   - Add `https://spark-scout-*.vercel.app/api/auth/callback/google` for each preview deployment
+   
+2. **Use a proxy redirect URL** (recommended):
+   - Set `AUTH_REDIRECT_PROXY_URL=https://spark-scout-eosin.vercel.app` (or your preferred stable domain)
+   - This ensures all OAuth callbacks go through a consistent domain
+
+## Common Issues and Solutions
+
+1. **Redirect URI Mismatch Error**:
+   - Ensure all URIs in your Google Cloud Console match exactly with what your application is using
+   - The URI must include the exact protocol (http/https), domain, and path
+   - Trailing slashes matter - be consistent
+
+2. **Environment Variables Not Loaded**:
+   - Check that you're setting them for the correct environments (Production, Preview, Development)
+   - Some variables may need to be set for all environments
+
+3. **Cookie Issues**:
+   - If using a proxy redirect URL, set `NEXTAUTH_URL=https://spark-scout-eosin.vercel.app`
+   - You may also need `AUTH_TRUST_HOST=true` for Vercel deployments

--- a/VERCEL_OAUTH_SETUP.md
+++ b/VERCEL_OAUTH_SETUP.md
@@ -1,0 +1,132 @@
+# Setting up Vercel Environment Variables for Google OAuth
+
+## Prerequisites
+
+Before setting environment variables, make sure you have:
+1. Your Google OAuth 2.0 Client ID
+2. Your Google OAuth 2.0 Client Secret
+
+These can be found in your Google Cloud Console under "APIs & Services" > "Credentials".
+
+## Step-by-Step Setup
+
+### Step 1: Navigate to Your Project Directory
+
+Open your terminal and navigate to your Spark Scout project directory:
+```bash
+cd /project/workspace/OpulentiaAI/spark-scout
+```
+
+### Step 2: Login to Vercel
+
+Run the following command in your terminal:
+```bash
+vercel login
+```
+
+This will open a browser window where you can authenticate with your Vercel account.
+
+### Step 3: Set AUTH_GOOGLE_ID
+
+Set your Google OAuth Client ID:
+```bash
+vercel env add AUTH_GOOGLE_ID
+```
+
+When prompted:
+1. Enter your Google OAuth Client ID
+2. Select all environments (Production, Preview, and Development) by pressing Space to select each one, then press Enter
+
+### Step 4: Set AUTH_GOOGLE_SECRET
+
+Set your Google OAuth Client Secret:
+```bash
+vercel env add AUTH_GOOGLE_SECRET
+```
+
+When prompted:
+1. Enter your Google OAuth Client Secret
+2. Select all environments (Production, Preview, and Development) by pressing Space to select each one, then press Enter
+
+### Step 5: Set AUTH_SECRET
+
+Set your Auth Secret:
+```bash
+vercel env add AUTH_SECRET
+```
+
+When prompted:
+1. Generate a secure random secret (you can use https://generate-secret.vercel.app/32 or run `openssl rand -base64 32` in another terminal)
+2. Enter the generated secret
+3. Select all environments (Production, Preview, and Development) by pressing Space to select each one, then press Enter
+
+## Alternative Environment Variables for Better Deployment Handling
+
+### AUTH_REDIRECT_PROXY_URL
+
+To ensure consistent OAuth callbacks across all deployments:
+```bash
+vercel env add AUTH_REDIRECT_PROXY_URL
+```
+
+Set it to one of your domains:
+- For your main deployment: `https://spark-scout-eosin.vercel.app`
+- For your custom domain: `https://chat.opulentia.ai`
+
+### AUTH_TRUST_HOST
+
+To tell NextAuth to trust the Vercel host headers:
+```bash
+vercel env add AUTH_TRUST_HOST
+```
+
+Set it to `true` for all environments.
+
+## Verification Steps
+
+### Check Environment Variables
+
+To verify that your environment variables are set correctly:
+```bash
+vercel env list
+```
+
+This will show all environment variables configured for your project.
+
+### Pull Environment Variables Locally (Optional)
+
+If you want to test locally:
+```bash
+vercel env pull
+```
+
+This will create a `.env.local` file with all your environment variables (this file should NOT be committed to version control).
+
+### Redeploy Your Application
+
+After setting the environment variables, redeploy your application:
+```bash
+vercel --prod
+```
+
+This will ensure that the new environment variables are used in your production deployment.
+
+## Troubleshooting
+
+If you're still experiencing redirect_uri_mismatch errors after setting these variables:
+
+1. Double-check that your redirect URIs in Google Cloud Console exactly match:
+   - `https://spark-scout-eosin.vercel.app/api/auth/callback/google`
+   - `https://chat.opulentia.ai/api/auth/callback/google`
+   - `https://localhost:3000/api/auth/callback/google`
+
+2. Make sure you've selected the correct project when running vercel commands:
+   ```bash
+   vercel link
+   ```
+   This command will help you select the correct Vercel project if you have multiple.
+
+3. Check the Vercel logs for any authentication errors:
+   ```bash
+   vercel logs
+   ```


### PR DESCRIPTION
This PR adds comprehensive documentation to fix the Google OAuth redirect_uri_mismatch error by providing clear instructions for:\n\n- Setting up OAuth credentials in Google Cloud Console\n- Configuring environment variables in Vercel\n- Handling preview deployments with proxy URLs\n- Troubleshooting common OAuth issues\n\nFiles included:\n- AUTHENTICATION_SETUP.md: Main guide for OAuth configuration\n- OAUTH_ENV_VARIABLES.md: Detailed environment variable setup\n- VERCEL_OAUTH_SETUP.md: Step-by-step Vercel CLI instructions\n- Updated DEPLOYMENT.md with OAuth-specific deployment instructions\n\nThese documents will help resolve authentication issues and provide clear guidance for future deployments.