### PR TITLE
Make Temporal optional for chat streaming via NEXT_PUBLIC_TEMPORAL_ENABLED

### DIFF
--- a/hooks/useTemporalChat.ts
+++ b/hooks/useTemporalChat.ts
@@ -3,6 +3,8 @@
 import { useState, useCallback } from 'react';
 import type { ModelConfig, ChatMessage } from '@/temporal/types/workflow-types';
 
+const TEMPORAL_ENABLED = process.env.NEXT_PUBLIC_TEMPORAL_ENABLED === 'true';
+
 export function useTemporalChat() {
   const [isUpdating, setIsUpdating] = useState(false);
   const [currentWorkflowId, setCurrentWorkflowId] = useState<string | null>(null);
@@ -69,6 +71,9 @@ export function useTemporalChat() {
       modelConfig: ModelConfig,
       initialMessages: ChatMessage[] = [],
     ) => {
+      if (!TEMPORAL_ENABLED) {
+        return null;
+      }
       try {
         const res = await fetch('/api/temporal/start-chat', {
           method: 'POST',
@@ -92,6 +97,9 @@ export function useTemporalChat() {
     approvalWorkflowId,
     // Phase 8: approval workflow hooks via API
     requestApproval: async (request: any) => {
+      if (!TEMPORAL_ENABLED) {
+        return { ok: false } as { ok: boolean; approvalWorkflowId?: string };
+      }
       try {
         const res = await fetch('/api/temporal/approvals/request', {
           method: 'POST',
@@ -110,6 +118,7 @@ export function useTemporalChat() {
       }
     },
     getPendingApprovals: async () => {
+      if (!TEMPORAL_ENABLED) return [] as any[];
       try {
         if (!approvalWorkflowId) return [] as any[];
         const res = await fetch(`/api/temporal/approvals/pending?approvalWorkflowId=${approvalWorkflowId}`);
@@ -121,6 +130,7 @@ export function useTemporalChat() {
       }
     },
     approveRequest: async (requestId: string, approved: boolean, feedback?: string) => {
+      if (!TEMPORAL_ENABLED) return { ok: false } as { ok: boolean };
       try {
         if (!approvalWorkflowId) return { ok: false };
         const res = await fetch('/api/temporal/approvals/approve', {


### PR DESCRIPTION
Title: Make Temporal optional for chat streaming via NEXT_PUBLIC_TEMPORAL_ENABLED

Summary
- Remove Temporal requirement for basic chat streaming by gating all client-side Temporal calls behind NEXT_PUBLIC_TEMPORAL_ENABLED (default: off).
- Keeps model selection cookie updates intact; Temporal APIs remain available but are not invoked unless explicitly enabled.
- Improves deployability on Vercel and simplifies local usage without a running Temporal service.

Changes
- hooks/useTemporalChat.ts: 
  - Added TEMPORAL_ENABLED flag: const TEMPORAL_ENABLED = process.env.NEXT_PUBLIC_TEMPORAL_ENABLED === 'true'.
  - startChat now no-ops and returns null when disabled.
  - Approval helpers (requestApproval, getPendingApprovals, approveRequest) no-op when disabled.
  - Existing updateModel continues to set the model cookie; Temporal update is skipped unless a workflow is active and Temporal is enabled.

Why
- Streaming via the /api/chat route is independent of Temporal. Previously, the UI attempted to start/signals workflows opportunistically, which could fail when Temporal isn’t provisioned.
- This change removes that implicit requirement so streaming works out-of-the-box without running a Temporal service.

Impact
- No breaking changes. Existing Temporal deployments can enable the feature by setting NEXT_PUBLIC_TEMPORAL_ENABLED=true in the environment.
- When disabled, UI will not try to connect to Temporal; server-side Temporal API routes remain intact for future/optional usage.

Deployment
- Vercel production: add NEXT_PUBLIC_TEMPORAL_ENABLED=true only if you want the client to talk to Temporal.
- No change required for basic streaming; default behavior uses the non-Temporal /api/chat SSE pipeline.

Testing
- Manual: Verified that sending a message streams as usual without any Temporal service.
- Temporal paths are only exercised when NEXT_PUBLIC_TEMPORAL_ENABLED=true.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/571ecdaa-84af-11f0-a94e-3eef481a796b/task/49b5512e-481d-484d-8c70-2047070adc20))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a runtime toggle to enable or disable Temporal-powered chat and approval flows without redeploying.
- Bug Fixes
  - When disabled, the app no longer calls Temporal APIs and returns safe defaults (e.g., start chat returns null, approvals return empty or unsuccessful states), preventing errors and unintended requests.
- Documentation
  - Clarified behavior when the Temporal feature is disabled to set expectations for chat and approval functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->